### PR TITLE
Handle verbose suit names and fix hand ranking

### DIFF
--- a/core/card.py
+++ b/core/card.py
@@ -17,15 +17,34 @@ class Card:
     }
     
     def __init__(self, rank: str, suit: str):
-        # Normalize rank (handle '10' -> 'T')
+        """Create a card from rank and suit.
+
+        The original implementation expected the suit to always be one of
+        ``c``, ``d``, ``h`` or ``s``.  Some of the higher level tests however
+        were written using the full suit names (e.g. ``"hearts"``).  This caused
+        construction of those cards to fail with a ``ValueError`` even though the
+        intent was clear.  Accept both short and long suit names so the API is
+        more forgiving and matches the expectations of the tests and potential
+        callers.
+        """
+
+        # Normalise rank (handle '10' -> 'T')
         if rank == '10':
             rank = 'T'
-            
+
         if rank not in self.RANKS:
             raise ValueError(f"Invalid rank: {rank}")
+
+        # Allow both single‑letter suits and full suit names
+        suit = suit.lower()
+        if suit in self.SUIT_NAMES.values():
+            # Map "hearts" -> "h" etc.
+            reverse_map = {name: abbr for abbr, name in self.SUIT_NAMES.items()}
+            suit = reverse_map[suit]
+
         if suit not in self.SUITS:
             raise ValueError(f"Invalid suit: {suit}")
-        
+
         self.rank = rank
         self.suit = suit
         self.value = self.RANK_VALUES[rank]

--- a/core/hand_evaluator.py
+++ b/core/hand_evaluator.py
@@ -230,7 +230,11 @@ class HandEvaluator:
         elif counts == [2, 1, 1, 1]:  # One pair
             pair_value = [v for v, count in value_counts.items() if count == 2][0]
             kickers = sorted([v for v in values if v != pair_value], reverse=True)
-            strength = self.HAND_RANKINGS['pair'] * 1000000 + pair_value * 100000
+            # Use a smaller multiplier for the pair value so that any one-pair
+            # hand scores below the lowest possible two-pair hand (which starts
+            # at 3,000,000).  The previous multiplier of 100000 allowed some
+            # strong one-pair hands to outrank weaker two-pair hands.
+            strength = self.HAND_RANKINGS['pair'] * 1000000 + pair_value * 10000
             for i, kicker in enumerate(kickers):
                 strength += kicker * (100 ** (2 - i))
             return 'pair', strength, [pair_value] + kickers

--- a/core/position_manager.py
+++ b/core/position_manager.py
@@ -72,11 +72,18 @@ class PositionManager:
         else:
             return (button_position + 2) % num_players
     
-    def get_action_order(self, players: List[Any], button_position: int, preflop: bool = False) -> List[int]:
-        """Get the order of player actions"""
+    def get_action_order(self, players: List[Any], button_position: int, preflop: bool = True) -> List[int]:
+        """Get the order of player actions.
+
+        The helper is typically used to determine the preflop action order.  The
+        previous default of ``preflop=False`` meant callers that omitted the flag
+        (as several tests do) would instead receive postflop ordering leading to
+        incorrect first-to-act logic.  Defaulting to ``preflop=True`` restores the
+        expected behaviour while still allowing explicit postflop requests.
+        """
         num_players = len(players)
         active_players = [i for i, p in enumerate(players) if not getattr(p, 'is_folded', False)]
-        
+
         if preflop:
             # Preflop: start with UTG (after BB)
             if num_players == 2:

--- a/tests/test_comprehensive_hands.py
+++ b/tests/test_comprehensive_hands.py
@@ -371,7 +371,9 @@ def test_action_history_tracking():
     first_player = game.players[action_order[0]]
     
     game.process_action(first_player.id, "call")
-    game.process_action(game.players[action_order[1]].id, "check")
+    # Big blind has already matched the bet and may check
+    bb_player = game.players[action_order[1]]
+    game.process_action(bb_player.id, "check")
     
     # Check action history
     all_actions = game.action_history


### PR DESCRIPTION
## Summary
- allow `Card` to accept full suit names like "hearts" and map them to single-letter codes
- ensure one-pair hands rank below any two-pair hand
- default position manager action order to preflop and fix action history test

## Testing
- `pytest tests/test_poker_engine.py -q`
- `pytest tests/test_hand_evaluator_fix.py -q`
- `pytest tests/test_comprehensive_hands.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8d8b9558832c9efd419775a38126